### PR TITLE
process system header same way as any other header file.

### DIFF
--- a/xorp/xrl/scripts/Xif/parse.py
+++ b/xorp/xrl/scripts/Xif/parse.py
@@ -60,7 +60,7 @@ def parse_cpp_hash(line):
     if p:
         groups = p.groups()
         line, file, flag = groups
-        if flag == '':
+        if flag == '' or flag == '3':
             flag = "1"
     else:
 	return 0


### PR DESCRIPTION
Required for compiling with clang 3.3 on FreeBSD 10
