### PR TITLE
UPSTREAM: added aarch64 machine type in config.sub

### DIFF
--- a/xorp/config.sub
+++ b/xorp/config.sub
@@ -249,6 +249,7 @@ case $basic_machine in
 	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
 	| am33_2.0 \
 	| arc | arm | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
+	| aarch64 \
 	| bfin \
 	| c4x | clipper \
 	| d10v | d30v | dlx | dsp16xx \


### PR DESCRIPTION
Description:
When building with aarch64-unknown-linux-gnu cross toolchain the build
breaks with error "Invalid configuration `aarch64-linux': machine `aarch64' not recognized ".
Added arm 64bit support in config.sub file.

Signed-off-by: Niranjan Reddy <niranjan.reddy@rockwellcollins.com>